### PR TITLE
trim #s with pure js

### DIFF
--- a/custom-code-library.hbs
+++ b/custom-code-library.hbs
@@ -64,7 +64,7 @@
             <div>
                 {{#get "tags" limit="all"}}
                     {{#foreach tags visibility="internal"}}
-                        <h1>{{{trimString name}}} Routines</h1>
+                        <h1 class="code-library-header">{{ name }} Routines</h1>
                         {{#get "posts" filter="tags:{{slug}}"}}
                         {{#foreach posts}}
                         {{> "code-card"}}
@@ -75,6 +75,14 @@
         </div>
     </div>
     </section>
+    <script>
+        {
+            var headers = document.GetElementsByClassName("code-library-header")
+            for (let h of headers) {
+                h.innerHTML = h.innerHTML.substring(1);
+            }
+        }
+    </script>
 
     {{!--
     <section class="article-comments gh-canvas">

--- a/custom-code-library.hbs
+++ b/custom-code-library.hbs
@@ -77,7 +77,7 @@
     </section>
     <script>
         {
-            var headers = document.GetElementsByClassName("code-library-header")
+            var headers = document.getElementsByClassName("code-library-header")
             for (let h of headers) {
                 h.innerHTML = h.innerHTML.substring(1);
             }


### PR DESCRIPTION
rather than muck with ghost trying to force a helper in. We can achieve basically the same thing by just adding in a class and a bit of pure js.

_note - the surrounding brackets define a local scope so that we don't clobber any_ ` var headers` _which may exist in the global scope._