### PR TITLE
Replace Ghost's built-in signup link with MailerLite form

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -60,7 +60,18 @@
                 </div>
 
                 {{#unless @member}}
-                    <a class="gh-head-button" href="#/portal/signup">Subscribe</a>
+                    <button class="ml-onclick-form" onclick="ml('show', 'HflJMM', true)" style="
+                            background-color: #FFF; 
+                            color: #15171a;
+                            padding: 5.1px 15px; 
+                            font-size: 1.5rem; 
+                            margin-right: 15px;
+                            font-weight: 500;
+                            letter-spacing: -0.015em;
+                            border-radius: 30px; 
+                            cursor: pointer;">
+                        Sign Up
+                    </button>
                 {{else}}
                     <a class="gh-head-button" href="#/portal/account">Account</a>
                 {{/unless}}

--- a/post.hbs
+++ b/post.hbs
@@ -103,10 +103,18 @@ into the {body} tag of the default.hbs template --}}
     <div class="inner">
         <h3>Never miss an article.</h3>
         <p>Sign up to receive a Sunday morning email with links and recaps of the seven articles published that week. <br/> (I'll never sell your email.  Unsubscribe any time.)</p><br/>
-        <a class="footer-cta-button" href="#/portal">
-            <div>Enter your email</div>
-            <span>Subscribe</span>
-        </a>
+        <button class="ml-onclick-form" onclick="ml('show', 'HflJMM', true)" style="
+                background-color: #FFF; 
+                color: #15171a;
+                border: black 1px solid;
+                padding: 8px 15px; 
+                font-size: 2.0rem; 
+                font-weight: 500;
+                letter-spacing: 0.005em;
+                border-radius: 10px; 
+                cursor: pointer;">
+            Subscribe
+        </button>
         {{!-- ^ This looks like a form element, but it's just a link to Portal,
         making the form validation and submission much simpler. --}}
     </div>   


### PR DESCRIPTION
- Replaced the "Subscribe" link for non-members (`@member`) with a custom MailerLite signup button.
- Integrated MailerLite's `ml()` function to display the signup form.
- Added inline styles for the new button to ensure a consistent and appealing design:
  - Background color: #FFF
  - Text color: #15171a
  - Padding, font size, margin, and border radius for better aesthetics.
- Retained Ghost's "Account" link for logged-in members.

This change transitions the subscription flow from Ghost's built-in system to MailerLite, providing more flexibility and additional features for email signup management.